### PR TITLE
Replace obsolete --rm-dist option of goreleaser with --clean

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -37,6 +37,6 @@ jobs:
         if: success() && startsWith(github.ref, 'refs/tags/')
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

Releases [fail](https://github.com/railsware/fakes3server/actions/runs/9952583274/job/27494202874#step:6:19) because of the obsolete `--rm-dist` option supplied to `goreleaser release`. Substituted with equivalent `--clean`.

## Changes

Updated the `.github/workflows/build-and-release.yml` workflow with the modern `goreleaser release --clean` option. 

## How to test

The Github workflow triggered by a new release from pushing a new tag should work

